### PR TITLE
feat(Backend): Added accounts api endpoints

### DIFF
--- a/backend/api/v1/accounts.py
+++ b/backend/api/v1/accounts.py
@@ -4,7 +4,7 @@ api/v1/accounts.py — Account management endpoints.
 Endpoints:
     GET    /api/v1/accounts/         — list accounts across the user's households
     POST   /api/v1/accounts/         — create an account in a household
-    PATCH  /api/v1/accounts/{id}/    — update an account's name or type
+    PATCH  /api/v1/accounts/{id}/    — rename an account
     DELETE /api/v1/accounts/{id}/    — delete an account
 """
 
@@ -13,6 +13,7 @@ from enum import Enum
 from typing import List, Optional
 
 from django.db import IntegrityError
+from django.db.models.deletion import ProtectedError
 from django.shortcuts import get_object_or_404
 from ninja import Router
 from ninja.errors import HttpError
@@ -136,7 +137,10 @@ def create_account(request, payload: AccountCreateRequest):
         raise HttpError(400, 'Account name cannot be blank.')
 
     household = _get_household_for_member(payload.household_id, request.user)
-    account_type = get_object_or_404(AccountType, pk=payload.account_type_id)
+    account_type = get_object_or_404(
+        AccountType.objects.select_related('bank'),
+        pk=payload.account_type_id,
+    )
 
     try:
         account = Account.objects.create(
@@ -152,16 +156,18 @@ def create_account(request, payload: AccountCreateRequest):
         f'"{account.name}" (id={account.id}) in household "{household.name}" (id={household.id}).'
     )
 
-    account = Account.objects.select_related('account_type__bank', 'household').get(pk=account.pk)
+    # Attach the already-fetched relations so _serialize has no extra queries.
+    account.account_type = account_type
+    account.household = household
     return _serialize(account)
 
 
 @router.patch('/accounts/{account_id}/', response=AccountDetailSchema)
 def rename_account(request, account_id: int, payload: AccountRenameRequest):
-    """Renames an account.
+    """Renames an existing account.
 
-    The user must be a member of the household the account belongs to. Account
-    names must be unique within a household.
+    The user must be a member of the household the account belongs to.
+    The new name must be unique within that household.
 
     Args:
         request: The HTTP request object. Must be authenticated.
@@ -172,8 +178,8 @@ def rename_account(request, account_id: int, payload: AccountRenameRequest):
         The updated AccountDetailSchema.
 
     Raises:
-        HttpError: 400 if the name is blank.
-        HttpError: 400 if an account with that name already exists in the household.
+        HttpError: 400 if the new name is blank.
+        HttpError: 400 if another account in the household already has that name.
         HttpError: 403 if the user is not a member of the household.
         HttpError: 404 if the account does not exist.
     """
@@ -230,7 +236,7 @@ def delete_account(request, account_id: int):
 
     try:
         account.delete()
-    except Exception:
+    except ProtectedError:
         raise HttpError(409, 'This account has transactions and cannot be deleted.')
 
     logger.info(

--- a/backend/schemas/accounts.py
+++ b/backend/schemas/accounts.py
@@ -10,6 +10,7 @@ class AccountCreateRequest(Schema):
     account_type_id: int
     name: str
 
+
 class AccountDetailSchema(Schema):
     """
     Full account representation returned after create and on list.

--- a/backend/tests/api/v1/test_accounts.py
+++ b/backend/tests/api/v1/test_accounts.py
@@ -7,7 +7,7 @@ import pytest
 from ninja.testing import TestClient
 
 from api.v1.accounts import router
-from transactions.models import Account, AccountType, Bank
+from transactions.models import Account, AccountType, Bank, Transaction
 from users.models import CustomUser, Household
 
 
@@ -293,7 +293,7 @@ class TestCreateAccount:
         )
         assert response.status_code == 404
 
-    def test_different_account_types_same_name_allowed(self, client, alice, household):
+    def test_different_account_types_same_name_not_allowed(self, client, alice, household):
         at_checking = AccountType.objects.get(handler_key='sofi-checking')
         at_savings = AccountType.objects.get(handler_key='sofi-savings')
 
@@ -316,15 +316,9 @@ class TestCreateAccount:
 class TestRenameAccount:
 
     def test_renames_account_successfully(self, client, alice, account):
-        response = client.patch(
-            f'/accounts/{account.id}/',
-            json={'name': 'Renamed Account'},
-            user=alice,
-        )
+        response = client.patch(f'/accounts/{account.id}/', json={'name': 'New Name'}, user=alice)
         assert response.status_code == 200
-        assert response.json()['name'] == 'Renamed Account'
-        account.refresh_from_db()
-        assert account.name == 'Renamed Account'
+        assert response.json()['name'] == 'New Name'
 
     def test_rename_is_persisted(self, client, alice, account):
         client.patch(f'/accounts/{account.id}/', json={'name': 'Persisted Rename'}, user=alice)
@@ -363,16 +357,13 @@ class TestRenameAccount:
         assert response.status_code == 200
         assert response.json()['name'] == account.name
 
+    def test_returns_403_if_not_a_member(self, client, bob, account):
+        response = client.patch(f'/accounts/{account.id}/', json={'name': 'Hacked'}, user=bob)
+        assert response.status_code == 403
+
     def test_returns_404_for_nonexistent_account(self, client, alice):
         response = client.patch('/accounts/9999/', json={'name': 'Does Not Exist'}, user=alice)
         assert response.status_code == 404
-
-    def test_returns_403_if_not_a_member(self, client, bob, account):
-        response = client.patch(f'/accounts/{account.id}/', json={'name': 'Hacker Name'}, user=bob)
-        assert response.status_code == 403
-        account.refresh_from_db()
-        assert account.name != 'Hacker Name'
-
 
 @pytest.mark.django_db
 class TestDeleteAccount:
@@ -390,3 +381,17 @@ class TestDeleteAccount:
         response = client.delete(f'/accounts/{account.id}/', user=bob)
         assert response.status_code == 403
         assert Account.objects.filter(pk=account.id).exists()
+
+    def test_returns_409_if_account_has_transactions(self, client, alice, account):
+        Transaction.objects.create(
+            id='a' * 32,
+            date='2026-01-15',
+            concept='TRADER JOES',
+            amount=-45.50,
+            account=account,
+        )
+        response = client.delete(f'/accounts/{account.id}/', user=alice)
+        assert response.status_code == 409
+        assert 'transactions' in response.json()['detail'].lower()
+        assert Account.objects.filter(pk=account.id).exists()
+        


### PR DESCRIPTION
## What & Why

Implements the accounts backend to support the Households frontend. Users can now create, list, rename, and delete accounts within their households.

**New router:** `api/v1/accounts.py` — registered in `config/api.py` alongside the existing routers.

**New schemas:** `schemas/accounts.py` — `AccountDetailSchema`, `AccountCreateRequest`, `AccountRenameRequest`.

**Endpoints:**

- `GET /api/v1/accounts/` — lists all accounts across the requesting user's households. Supports optional filtering by `household_id` and `bank_id`, and sorting by `bank` (default), `name`, `household`, or `created_at`.
- `POST /api/v1/accounts/` — creates an account in a household. Requires the user to select a bank, then an account type for that bank (seeded), and provide a name.
- `PATCH /api/v1/accounts/{id}/` — renames an account. Account type is intentionally immutable — to change type, delete and recreate.
- `DELETE /api/v1/accounts/{id}/` — deletes an account. Blocked with a 409 if the account has existing transactions (Django `PROTECT` constraint).

## Testing

- 35 new tests in `tests/api/v1/test_accounts.py` using Django Ninja's `TestClient`.
- `TestListAccounts` (13 tests): cross-household scoping, user isolation, household and bank filters individually and combined, all four sort orders, 403/404 on bad `household_id`, empty list, and response shape.
- `TestCreateAccount` (13 tests): happy path, persistence, whitespace trimming, blank name, duplicate name within household, same name across households, membership enforcement, missing household/account type.
- `TestRenameAccount` (9 tests): happy path, persistence, whitespace trimming, full response shape, blank name, duplicate name, same-name no-op, 403, 404.
- `TestDeleteAccount` (3 tests): happy path, 404, 403 with existence check.

## Follow-up

- The existing `GET /accounts` on the transactions router (used by the CSV import flow) is separate and unchanged — it remains unauthenticated and requires `household_id`. These two endpoints can be consolidated once the import UI is updated to use the new authenticated list endpoint.
- Pagination is not implemented — acceptable for now, given expected account counts per user, but worth revisiting if accounts grow significantly.

## Accessibility

No UI changes in this PR. Backend only.

## Security

- All four endpoints require authentication via `django_auth`.
- Every mutating endpoint (create, rename, delete) verifies the requesting user is a member of the relevant household before proceeding. Non-members receive a 403.
- `GET /accounts/` scopes the base queryset to `household__users=request.user`, so a user can never enumerate another user's accounts regardless of query params.
- If a `household_id` filter is provided on the list endpoint, membership is verified before filtering — a user cannot probe whether a household exists by passing an arbitrary ID.
- Account type is seeded and referenced by ID — users cannot inject arbitrary account types.
- Account names are trimmed and validated; the `unique_together` constraint on `(household, name)` is enforced at the DB level and surfaced cleanly as a 400.
- No sensitive financial data (transactions, balances) is exposed by these endpoints — accounts are metadata only.

## Checklist
- [x] Tested locally
- [x] Code is clean and commented where needed
- [x] No unintended side effects
- [x] Accessibility considered for any UI changes
- [x] No sensitive data leaked or improperly exposed