### PR TITLE
Added release.yml action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - production
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ github.run_number }}
+          name: Release v${{ github.run_number }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What & Why

Adds a GitHub Action that automatically creates a GitHub release every time a PR is merged into `production`. This gives us a clear release history and auto-generated release notes from PR descriptions.

## Testing

Will be validated when the first `main` → `production` PR is merged.

## Follow-up

None at this time.

## Accessibility

No UI changes in this PR.

## Security

No sensitive data or auth changes in this PR.

## Checklist
- [ ] Tested locally
- [ ] Code is clean and commented where needed
- [ ] No unintended side effects
- [ ] Accessibility considered for any UI changes
- [ ] No sensitive data leaked or improperly exposed