### PR TITLE
feat: add /settings route, user avatar menu, and unit tests

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { DashboardPage } from '@pages/dashboard';
 import { HouseholdsPage } from '@pages/households';
 import { LoginPage } from '@pages/login';
 import { RegisterPage } from '@pages/register';
+import { SettingsPage } from '@pages/settings';
 import { SummaryPage } from '@pages/summary';
 import { TransactionsPage } from '@pages/transactions';
 import theme from '@serve/theme';
@@ -79,6 +80,14 @@ export default function App() {
                 element={
                   <ProtectedRoute>
                     <TransactionsPage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/settings"
+                element={
+                  <ProtectedRoute>
+                    <SettingsPage />
                   </ProtectedRoute>
                 }
               />

--- a/frontend/src/layout/app-header/app-header.test.tsx
+++ b/frontend/src/layout/app-header/app-header.test.tsx
@@ -1,6 +1,8 @@
-import { act, render, screen, fireEvent } from '@testing-library/react';
+// layout/app-header/app-header.test.tsx
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuth } from '@context/auth-context';
 import { AppHeader } from '@layout/app-header';
@@ -9,6 +11,11 @@ import { logout } from '@services/auth';
 vi.mock('@context/auth-context', () => ({ useAuth: vi.fn() }));
 vi.mock('@services/auth', () => ({ logout: vi.fn() }));
 
+const mockNavigate = vi.fn();
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
 
 const mockUseAuth = vi.mocked(useAuth);
 const mockLogout = vi.mocked(logout);
@@ -22,35 +29,106 @@ const mockUser = {
   households: [],
 };
 
-describe('AppHeader', () => {
+function setup(userOverrides = {}) {
+  const setUser = vi.fn();
+  mockUseAuth.mockReturnValue({
+    user: { ...mockUser, ...userOverrides },
+    isLoading: false,
+    sessionError: false,
+    setUser,
+  });
+  render(<MemoryRouter><AppHeader /></MemoryRouter>);
+  return { setUser };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockNavigate.mockReset();
+});
+
+// ── Rendering ─────────────────────────────────────────────────────────────────
+
+describe('AppHeader rendering', () => {
   it('renders the logo', () => {
-    mockUseAuth.mockReturnValue({ user: mockUser, isLoading: false, sessionError: false, setUser: vi.fn() });
-
-    render(<MemoryRouter><AppHeader /></MemoryRouter>);
-
+    setup();
     expect(screen.getByAltText('SERVE')).toBeDefined();
   });
 
-  it("renders the user's email", () => {
-    mockUseAuth.mockReturnValue({ user: mockUser, isLoading: false, sessionError: false, setUser: vi.fn() });
-
-    render(<MemoryRouter><AppHeader /></MemoryRouter>);
-
-    expect(screen.getByText(mockUser.email)).toBeDefined();
+  it('renders the avatar button when a user is logged in', () => {
+    setup();
+    expect(screen.getByRole('button', { name: /open user menu/i })).toBeDefined();
   });
 
-  it('calls logout on sign out click', async () => {
-    const setUser = vi.fn();
-    mockUseAuth.mockReturnValue({ user: mockUser, isLoading: false, sessionError: false, setUser });
+  it('does not render the avatar button when there is no user', () => {
+    mockUseAuth.mockReturnValue({ user: null, isLoading: false, sessionError: false, setUser: vi.fn() });
+    render(<MemoryRouter><AppHeader /></MemoryRouter>);
+    expect(screen.queryByRole('button', { name: /open user menu/i })).toBeNull();
+  });
+});
+
+// ── Initials ──────────────────────────────────────────────────────────────────
+
+describe('AppHeader initials', () => {
+  it('shows first and last initial when both names are present', () => {
+    setup({ first_name: 'Test', last_name: 'User' });
+    expect(screen.getByText('TU')).toBeDefined();
+  });
+
+  it('shows only the first initial when last name is absent', () => {
+    setup({ first_name: 'Test', last_name: '' });
+    expect(screen.getByText('T')).toBeDefined();
+  });
+
+  it('falls back to the first character of the email when no name is present', () => {
+    setup({ first_name: '', last_name: '' });
+    expect(screen.getByText('T')).toBeDefined(); // 't' from 'test@example.com' uppercased
+  });
+});
+
+// ── Dropdown ──────────────────────────────────────────────────────────────────
+
+describe('AppHeader dropdown', () => {
+  it('opens the menu when the avatar button is clicked', () => {
+    setup();
+    expect(screen.queryByRole('menuitem', { name: /settings/i })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /open user menu/i }));
+    expect(screen.getByRole('menuitem', { name: /settings/i })).toBeDefined();
+    expect(screen.getByRole('menuitem', { name: /sign out/i })).toBeDefined();
+  });
+
+  it('closes the menu when clicking outside (onClose)', () => {
+    setup();
+    fireEvent.click(screen.getByRole('button', { name: /open user menu/i }));
+    expect(screen.getByRole('menuitem', { name: /settings/i })).toBeDefined();
+    // Simulate MUI Menu onClose (e.g. backdrop click / Escape)
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'Escape' });
+    expect(screen.queryByRole('menuitem', { name: /settings/i })).toBeNull();
+  });
+
+  it('navigates to /settings and closes the menu when Settings is clicked', () => {
+    setup();
+    fireEvent.click(screen.getByRole('button', { name: /open user menu/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /settings/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/settings');
+    expect(screen.queryByRole('menuitem', { name: /settings/i })).toBeNull();
+  });
+});
+
+// ── Logout ────────────────────────────────────────────────────────────────────
+
+describe('AppHeader logout', () => {
+  it('calls logout, clears the user, and navigates to /login on sign out', async () => {
+    const { setUser } = setup();
     mockLogout.mockResolvedValueOnce(undefined);
 
-    render(<MemoryRouter><AppHeader /></MemoryRouter>);
-
+    fireEvent.click(screen.getByRole('button', { name: /open user menu/i }));
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /sign out/i }));
+      fireEvent.click(screen.getByRole('menuitem', { name: /sign out/i }));
     });
 
     expect(mockLogout).toHaveBeenCalledOnce();
     expect(setUser).toHaveBeenCalledWith(null);
+    expect(mockNavigate).toHaveBeenCalledWith('/login');
   });
+
 });

--- a/frontend/src/layout/app-header/index.tsx
+++ b/frontend/src/layout/app-header/index.tsx
@@ -1,25 +1,50 @@
 // layout/app-header/index.tsx — Top navigation bar for authenticated pages.
 
-import { AppBar, Box, Button, Toolbar, Typography } from '@mui/material';
+import { AppBar, Avatar, Box, Divider, IconButton, Menu, MenuItem, Toolbar } from '@mui/material';
+import { useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import { useAuth } from '@context/auth-context';
 import { logout } from '@services/auth';
 
+/** Derives up-to-two-character initials from a user's name or email. */
+function getInitials(user: { first_name?: string; last_name?: string; email: string }): string {
+  if (user.first_name && user.last_name) {
+    return `${user.first_name[0]}${user.last_name[0]}`.toUpperCase();
+  }
+  if (user.first_name) {
+    return user.first_name[0].toUpperCase();
+  }
+  return user.email[0].toUpperCase();
+}
 
 export function AppHeader() {
   const { user, setUser } = useAuth();
   const navigate = useNavigate();
 
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+
+  function handleAvatarClick(e: React.MouseEvent<HTMLElement>) {
+    setMenuAnchor(e.currentTarget);
+  }
+
+  function handleClose() {
+    setMenuAnchor(null);
+  }
+
   async function handleLogout() {
+    handleClose();
     try {
       await logout();
     } finally {
-      // Clear user regardless of whether the API call succeeded,
-      // so a failed logout doesn't leave the user stuck.
       setUser(null);
       navigate('/login');
     }
+  }
+
+  function handleSettings() {
+    handleClose();
+    navigate('/settings');
   }
 
   return (
@@ -36,12 +61,35 @@ export function AppHeader() {
           alt="SERVE"
           sx={{ height: 100, mr: 'auto' }}
         />
-        <Typography variant="body2" color="text.secondary" sx={{ mr: 2 }}>
-          {user?.email}
-        </Typography>
-        <Button onClick={handleLogout} color="primary" size="small">
-          Sign out
-        </Button>
+        {user && (
+          <>
+            <IconButton
+              onClick={handleAvatarClick}
+              size="small"
+              aria-label="Open user menu"
+              aria-controls={menuAnchor ? 'user-menu' : undefined}
+              aria-haspopup="true"
+              aria-expanded={menuAnchor ? 'true' : undefined}
+            >
+              <Avatar sx={{ width: 50, height: 50, fontSize: 20, bgcolor: 'primary.main' }}>
+                {getInitials(user)}
+              </Avatar>
+            </IconButton>
+            <Menu
+              id="user-menu"
+              anchorEl={menuAnchor}
+              open={Boolean(menuAnchor)}
+              onClose={handleClose}
+              anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+              transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+              slotProps={{ paper: { elevation: 2, sx: { mt: 0.5, minWidth: 160 } } }}
+            >
+              <MenuItem onClick={handleSettings}>Settings</MenuItem>
+              <Divider />
+              <MenuItem onClick={handleLogout}>Sign out</MenuItem>
+            </Menu>
+          </>
+        )}
       </Toolbar>
     </AppBar>
   );

--- a/frontend/src/pages/settings/index.tsx
+++ b/frontend/src/pages/settings/index.tsx
@@ -1,0 +1,68 @@
+// pages/settings/index.tsx — User settings page shell.
+//
+// Hosts profile, password, and subscription management sections.
+// Section content is populated in follow-up issues; this file
+// establishes the layout, route entry point, and empty placeholders.
+
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { Box, Button, Container, Divider, Paper, Typography } from '@mui/material';
+import { useNavigate } from 'react-router';
+
+import { AppHeader } from '@layout/app-header';
+
+export function SettingsPage() {
+  const navigate = useNavigate();
+
+  return (
+    <Box sx={{ minHeight: '100vh', bgcolor: 'background.default' }}>
+      <AppHeader />
+
+      <Container maxWidth="sm" sx={{ py: 6 }}>
+        <Button
+          startIcon={<ArrowBackIcon />}
+          onClick={() => navigate('/')}
+          size="small"
+          sx={{ mb: 3, color: 'text.secondary' }}
+        >
+          Dashboard
+        </Button>
+
+        <Typography variant="h3" sx={{ mb: 0.5 }}>
+          Settings
+        </Typography>
+        <Typography color="text.secondary" sx={{ mb: 5 }}>
+          Manage your profile and subscription.
+        </Typography>
+
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          {/* Profile — populated in Issue 2 */}
+          <Paper variant="outlined" sx={{ p: 3 }}>
+            <Typography variant="h6" sx={{ mb: 0.5 }}>
+              Profile
+            </Typography>
+            <Divider sx={{ mb: 2 }} />
+            {/* TODO: name, username, and email editing (Issue 2) */}
+          </Paper>
+
+          {/* Password — populated in Issue 3 */}
+          <Paper variant="outlined" sx={{ p: 3 }}>
+            <Typography variant="h6" sx={{ mb: 0.5 }}>
+              Password
+            </Typography>
+            <Divider sx={{ mb: 2 }} />
+            {/* TODO: change password form (Issue 3) */}
+          </Paper>
+
+          {/* Subscription — populated in Issue 4 */}
+          <Paper variant="outlined" sx={{ p: 3 }}>
+            <Typography variant="h6" sx={{ mb: 0.5 }}>
+              Subscription
+            </Typography>
+            <Divider sx={{ mb: 2 }} />
+            {/* TODO: subscription plan display (Issue 4) */}
+          </Paper>
+        </Box>
+      </Container>
+    </Box>
+  );
+}

--- a/frontend/src/pages/settings/settings.test.tsx
+++ b/frontend/src/pages/settings/settings.test.tsx
@@ -1,0 +1,69 @@
+// pages/settings/settings.test.tsx
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SettingsPage } from '@pages/settings';
+
+vi.mock('@context/auth-context', () => ({
+  useAuth: () => ({
+    user: { id: 1, email: 'test@example.com', first_name: 'Test', last_name: 'User', username: 'test', households: [] },
+    setUser: vi.fn(),
+  }),
+}));
+vi.mock('@layout/app-header', () => ({ AppHeader: () => <header /> }));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function renderPage() {
+  return render(<MemoryRouter><SettingsPage /></MemoryRouter>);
+}
+
+// ── Rendering ─────────────────────────────────────────────────────────────────
+
+describe('SettingsPage rendering', () => {
+  it('renders the page heading', () => {
+    renderPage();
+    expect(screen.getByRole('heading', { name: /^settings$/i })).toBeDefined();
+  });
+
+  it('renders the subheading', () => {
+    renderPage();
+    expect(screen.getByText(/manage your profile and subscription/i)).toBeDefined();
+  });
+
+  it('renders the Profile section', () => {
+    renderPage();
+    expect(screen.getByRole('heading', { name: /^profile$/i })).toBeDefined();
+  });
+
+  it('renders the Password section', () => {
+    renderPage();
+    expect(screen.getByRole('heading', { name: /^password$/i })).toBeDefined();
+  });
+
+  it('renders the Subscription section', () => {
+    renderPage();
+    expect(screen.getByRole('heading', { name: /^subscription$/i })).toBeDefined();
+  });
+
+  it('renders the back to dashboard button', () => {
+    renderPage();
+    expect(screen.getByRole('button', { name: /dashboard/i })).toBeDefined();
+  });
+});
+
+// ── Navigation ────────────────────────────────────────────────────────────────
+
+describe('SettingsPage navigation', () => {
+  it('navigates to / when the back button is clicked', () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /dashboard/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+});


### PR DESCRIPTION
## What & Why
<!-- What does this PR do, and why? Include any relevant context or motivation. -->
Adds a `/settings` route and page shell as a prerequisite for profile editing, password changes, and subscription management. The name "Settings" was chosen deliberately over "Account" to avoid ambiguity with the existing financial Accounts page.

Access is via a new user avatar (`IconButton` + `Avatar`) in `AppHeader`, replacing the previous standalone Sign out button. Clicking the avatar opens a dropdown `Menu` with Settings and Sign out items. The avatar displays the user's initials (first + last, first only, or email fallback) and is sized at 50×50px. The settings page itself renders three empty `Paper` section placeholders — Profile, Password, and Subscription — to be populated in follow-up issues.

Affected components: `App.tsx`, `AppHeader`, `pages/settings/index.tsx`. Unit tests added for both `AppHeader` and `SettingsPage`.

## Testing
<!-- How did you test this? -->
Unit tests added with Vitest + React Testing Library:

**`app-header.test.tsx`** (10 tests):
- Logo renders; avatar button shows when logged in, hidden when logged out
- All three branches of the `getInitials` helper (first+last, first only, email fallback)
- Dropdown opens on avatar click, closes on Escape, Settings click navigates to `/settings` and closes the menu
- Sign out calls `logout()`, clears the user via `setUser(null)`, and navigates to `/login`

**`settings.test.tsx`** (6 tests):
- Page heading, subheading, and all three section headings render
- Back button renders and navigates to `/`

Manual browser testing: `/settings` renders correctly when authenticated; unauthenticated navigation to `/settings` redirects to `/login` via `ProtectedRoute`.

## Follow-up
<!-- Any known limitations, TODOs, or future work? -->
- Issue 2: Populate Profile section (name, username, email editing)
- Issue 3: Populate Password section (change password form)
- Issue 4: Populate Subscription section (plan display)
- Settings page tests will expand as sections are populated in follow-up issues

## Accessibility
<!-- Does this change affect the UI?
     - Is it keyboard navigable and screen reader friendly?
     - Are color contrasts, font sizes, and focus states appropriate? -->
The avatar `IconButton` carries `aria-label="Open user menu"`, `aria-haspopup="true"`, and `aria-expanded` tied to menu open state. MUI `Menu` handles focus trapping and Escape-to-close natively. Avatar is 50×50px with a 20px font size, well above minimum touch target and legibility thresholds.

## Security
<!-- Does this change touch sensitive financial data?
     - Is any new data exposed, stored, or transmitted?
     - Are inputs validated and sanitized?
     - Are auth/permission checks in place? -->
The `/settings` route is wrapped in `ProtectedRoute` — unauthenticated users are redirected to `/login`. No new data is exposed or transmitted in this PR; all section content is deferred to follow-up issues. The sign out flow clears the user from auth context in a `finally` block, so a failed API call cannot leave the user stuck in an authenticated state.

## Checklist
- [ ] Tested locally
- [ ] Code is clean and commented where needed
- [ ] No unintended side effects
- [ ] Accessibility considered for any UI changes
- [ ] No sensitive data leaked or improperly exposed