### PR TITLE
feat: add PATCH /auth/me endpoint and profile editing form

### DIFF
--- a/backend/api/v1/auth.py
+++ b/backend/api/v1/auth.py
@@ -1,11 +1,12 @@
 """
-api/v1/users.py — v1 authentication endpoints.
+api/v1/auth.py — v1 authentication endpoints.
 
 Endpoints:
-    POST /api/v1/auth/register — create a new user account
-    POST /api/v1/auth/login    — authenticate with email + password, start a session
-    POST /api/v1/auth/logout   — invalidate the current session
-    GET  /api/v1/auth/me       — return the current authenticated user
+    POST  /api/v1/auth/register — create a new user account
+    POST  /api/v1/auth/login    — authenticate with email + password, start a session
+    POST  /api/v1/auth/logout   — invalidate the current session
+    GET   /api/v1/auth/me       — return the current authenticated user
+    PATCH /api/v1/auth/me       — update the current user's profile fields
 """
 
 import logging
@@ -13,19 +14,28 @@ import secrets
 
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.password_validation import validate_password
+from django.contrib.auth.validators import UnicodeUsernameValidator
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 from ninja import Router
 from ninja.errors import HttpError
 from ninja.security import django_auth
 
-from schemas.auth import LoginRequest, MessageResponse, RegisterRequest, UserSchema
+from schemas.auth import (
+    LoginRequest,
+    MessageResponse,
+    RegisterRequest,
+    UpdateProfileRequest,
+    UserSchema,
+)
 from users.models import CustomUser
 from users.validators import validate_email_format
 
 logger = logging.getLogger(__name__)
 
 router = Router(tags=['Auth'])
+
+_username_validator = UnicodeUsernameValidator()
 
 
 # ── Endpoints ─────────────────────────────────────────────────────────────────
@@ -170,6 +180,81 @@ def auth_me(request):
         A UserSchema representing the current user.
     """
     user = CustomUser.objects.prefetch_related('households').get(pk=request.user.pk)
+    return _serialize_user(user)
+
+
+@router.patch('/auth/me', auth=django_auth, response=UserSchema)
+def auth_update_profile(request, payload: UpdateProfileRequest):
+    """Updates the current user's profile fields.
+
+    All fields are optional — only fields explicitly included in the request
+    body are updated. An empty payload is a valid no-op and returns the
+    current user unchanged.
+
+    Validation rules:
+    - first_name / last_name: blank strings are rejected.
+    - email: normalised to lowercase, format-validated, must be unique
+      excluding the current user.
+    - username: must satisfy Django's UnicodeUsernameValidator, max 150
+      chars, and be unique excluding the current user.
+
+    Args:
+        request: The HTTP request object. Must be authenticated.
+        payload: Partial profile update fields.
+
+    Returns:
+        A UserSchema representing the updated user.
+
+    Raises:
+        HttpError: 400 for blank values, invalid formats, or uniqueness
+            violations.
+    """
+    user: CustomUser = request.user
+    update_fields: list[str] = []
+
+    if payload.first_name is not None:
+        if not payload.first_name.strip():
+            raise HttpError(400, 'First name cannot be blank.')
+        user.first_name = payload.first_name
+        update_fields.append('first_name')
+
+    if payload.last_name is not None:
+        if not payload.last_name.strip():
+            raise HttpError(400, 'Last name cannot be blank.')
+        user.last_name = payload.last_name
+        update_fields.append('last_name')
+
+    if payload.email is not None:
+        if not payload.email.strip():
+            raise HttpError(400, 'Email cannot be blank.')
+        if email_error := validate_email_format(payload.email):
+            raise HttpError(400, email_error)
+        email = payload.email.lower()
+        if CustomUser.objects.filter(email=email).exclude(pk=user.pk).exists():
+            raise HttpError(400, 'An account with this email already exists.')
+        user.email = email
+        update_fields.append('email')
+
+    if payload.username is not None:
+        if not payload.username.strip():
+            raise HttpError(400, 'Username cannot be blank.')
+        if len(payload.username) > 150:
+            raise HttpError(400, 'Username must be 150 characters or fewer.')
+        try:
+            _username_validator(payload.username)
+        except ValidationError as e:
+            raise HttpError(400, ' '.join(e.messages)) from None
+        if CustomUser.objects.filter(username=payload.username).exclude(pk=user.pk).exists():
+            raise HttpError(400, 'This username is already taken.')
+        user.username = payload.username
+        update_fields.append('username')
+
+    if update_fields:
+        user.save(update_fields=update_fields)
+        logger.info(f'User {user.pk} updated profile fields: {update_fields}.')
+
+    user.refresh_from_db()
+    user = CustomUser.objects.prefetch_related('households').get(pk=user.pk)
     return _serialize_user(user)
 
 

--- a/backend/api/v1/auth.py
+++ b/backend/api/v1/auth.py
@@ -253,13 +253,17 @@ def auth_update_profile(request, payload: UpdateProfileRequest):
         try:
             user.save(update_fields=update_fields)
         except IntegrityError:
-            # A concurrent request inserted the same email or username between
-            # our uniqueness check and the save. Map to a 400 rather than 500.
-            # We can't always tell which field conflicted, so we return a
-            # generic message; the pre-save checks above handle the clear cases.
-            raise HttpError(
-                400, 'A duplicate email or username was submitted. Please try again.'
-            ) from None
+            if (
+                'email' in update_fields
+                and CustomUser.objects.filter(email=user.email).exclude(pk=user.pk).exists()
+            ):
+                raise HttpError(400, 'An account with this email already exists.') from None
+            if (
+                'username' in update_fields
+                and CustomUser.objects.filter(username=user.username).exclude(pk=user.pk).exists()
+            ):
+                raise HttpError(400, 'This username is already taken.') from None
+            raise HttpError(400, 'Unable to update profile due to a conflicting value.') from None
         logger.info(f'User {user.pk} updated profile fields: {update_fields}.')
 
     user.refresh_from_db()

--- a/backend/api/v1/auth.py
+++ b/backend/api/v1/auth.py
@@ -250,7 +250,16 @@ def auth_update_profile(request, payload: UpdateProfileRequest):
         update_fields.append('username')
 
     if update_fields:
-        user.save(update_fields=update_fields)
+        try:
+            user.save(update_fields=update_fields)
+        except IntegrityError:
+            # A concurrent request inserted the same email or username between
+            # our uniqueness check and the save. Map to a 400 rather than 500.
+            # We can't always tell which field conflicted, so we return a
+            # generic message; the pre-save checks above handle the clear cases.
+            raise HttpError(
+                400, 'A duplicate email or username was submitted. Please try again.'
+            ) from None
         logger.info(f'User {user.pk} updated profile fields: {update_fields}.')
 
     user.refresh_from_db()

--- a/backend/schemas/auth.py
+++ b/backend/schemas/auth.py
@@ -1,5 +1,5 @@
 """
-schemas/users.py — API schemas for user-related endpoints.
+schemas/auth.py — API schemas for authentication endpoints.
 
 Schemas define the API contract independently from the database models.
 Fields that are internal to the database (e.g. password hashes, internal
@@ -41,6 +41,19 @@ class LoginRequest(Schema):
 
     email: str
     password: str
+
+
+class UpdateProfileRequest(Schema):
+    """Request schema for updating the current user's profile fields.
+
+    All fields are optional — only provided fields are updated.
+    Omitted fields are left unchanged on the user record.
+    """
+
+    first_name: str | None = None
+    last_name: str | None = None
+    username: str | None = None
+    email: str | None = None
 
 
 class MessageResponse(Schema):

--- a/backend/tests/api/v1/auth/test_update_profile.py
+++ b/backend/tests/api/v1/auth/test_update_profile.py
@@ -146,3 +146,16 @@ class TestUpdateProfile:
         client.patch('/auth/me', json={'first_name': 'Persisted'}, user=registered_user)
         registered_user.refresh_from_db()
         assert registered_user.first_name == 'Persisted'
+
+    # ── Concurrent update race ─────────────────────────────────────────────────
+
+    def test_integrity_error_on_save_returns_400_not_500(self, client, registered_user, mocker):
+        # Simulate a concurrent duplicate slipping past the uniqueness check.
+        from django.db import IntegrityError
+
+        mocker.patch(
+            'django.db.models.base.Model.save',
+            side_effect=IntegrityError('Duplicate entry'),
+        )
+        response = client.patch('/auth/me', json={'username': 'anynewname'}, user=registered_user)
+        assert response.status_code == 400

--- a/backend/tests/api/v1/auth/test_update_profile.py
+++ b/backend/tests/api/v1/auth/test_update_profile.py
@@ -149,13 +149,58 @@ class TestUpdateProfile:
 
     # ── Concurrent update race ─────────────────────────────────────────────────
 
-    def test_integrity_error_on_save_returns_400_not_500(self, client, registered_user, mocker):
-        # Simulate a concurrent duplicate slipping past the uniqueness check.
+    def test_concurrent_duplicate_email_returns_specific_400(
+        self, client, registered_user, db, mocker
+    ):
+        # Another user claims the email between our exists() check and save().
+        # Patch only CustomUser.save in the auth module so other.save() inside
+        # the side-effect is not intercepted (avoids infinite recursion).
+        other = CustomUser.objects.create_user(
+            username='other', email='race@example.com', password='Password1!'
+        )
+        from django.db import IntegrityError
+
+        def _steal_then_fail(*args, **kwargs):
+            CustomUser.objects.filter(pk=other.pk).update(email='race@example.com')
+            raise IntegrityError('Duplicate entry')
+
+        mocker.patch('api.v1.auth.CustomUser.save', side_effect=_steal_then_fail)
+        response = client.patch(
+            '/auth/me', json={'email': 'race@example.com'}, user=registered_user
+        )
+        assert response.status_code == 400
+        assert 'email already exists' in response.json()['detail'].lower()
+
+    def test_concurrent_duplicate_username_returns_specific_400(
+        self, client, registered_user, db, mocker
+    ):
+        # Another user claims the username between our exists() check and save().
+        # Patch only CustomUser.save in the auth module so other.save() inside
+        # the side-effect is not intercepted (avoids infinite recursion).
+        other = CustomUser.objects.create_user(
+            username='other', email='other3@example.com', password='Password1!'
+        )
+        from django.db import IntegrityError
+
+        def _steal_then_fail(*args, **kwargs):
+            CustomUser.objects.filter(pk=other.pk).update(username='racename')
+            raise IntegrityError('Duplicate entry')
+
+        mocker.patch('api.v1.auth.CustomUser.save', side_effect=_steal_then_fail)
+        response = client.patch('/auth/me', json={'username': 'racename'}, user=registered_user)
+        assert response.status_code == 400
+        assert 'username is already taken' in response.json()['detail'].lower()
+
+    def test_unidentified_integrity_error_returns_generic_400(
+        self, client, registered_user, mocker
+    ):
+        # IntegrityError on a non-email/username field falls back to the generic message.
         from django.db import IntegrityError
 
         mocker.patch(
-            'django.db.models.base.Model.save',
-            side_effect=IntegrityError('Duplicate entry'),
+            'api.v1.auth.CustomUser.save',
+            side_effect=IntegrityError('Duplicate entry on unknown column'),
         )
-        response = client.patch('/auth/me', json={'username': 'anynewname'}, user=registered_user)
+        response = client.patch('/auth/me', json={'first_name': 'Test'}, user=registered_user)
         assert response.status_code == 400
+        assert 'conflicting value' in response.json()['detail'].lower()

--- a/backend/tests/api/v1/auth/test_update_profile.py
+++ b/backend/tests/api/v1/auth/test_update_profile.py
@@ -1,0 +1,148 @@
+"""
+tests/api/v1/auth/test_update_profile.py — Tests for PATCH /auth/me.
+
+auth/conftest.py provides: client, registered_user.
+"""
+
+import pytest
+
+from users.models import CustomUser
+
+
+@pytest.mark.django_db
+class TestUpdateProfile:
+    # ── Auth ──────────────────────────────────────────────────────────────────
+
+    def test_unauthenticated_request_returns_401(self, client):
+        response = client.patch('/auth/me', json={})
+        assert response.status_code == 401
+
+    # ── No-op ─────────────────────────────────────────────────────────────────
+
+    def test_empty_payload_returns_current_user_unchanged(self, client, registered_user):
+        response = client.patch('/auth/me', json={}, user=registered_user)
+        assert response.status_code == 200
+        data = response.json()
+        assert data['email'] == registered_user.email
+        assert data['username'] == registered_user.username
+
+    # ── Individual field updates ──────────────────────────────────────────────
+
+    def test_update_first_name(self, client, registered_user):
+        response = client.patch('/auth/me', json={'first_name': 'Jane'}, user=registered_user)
+        assert response.status_code == 200
+        assert response.json()['first_name'] == 'Jane'
+
+    def test_update_last_name(self, client, registered_user):
+        response = client.patch('/auth/me', json={'last_name': 'Doe'}, user=registered_user)
+        assert response.status_code == 200
+        assert response.json()['last_name'] == 'Doe'
+
+    def test_update_username(self, client, registered_user):
+        response = client.patch('/auth/me', json={'username': 'newusername'}, user=registered_user)
+        assert response.status_code == 200
+        assert response.json()['username'] == 'newusername'
+
+    def test_update_email(self, client, registered_user):
+        response = client.patch('/auth/me', json={'email': 'new@example.com'}, user=registered_user)
+        assert response.status_code == 200
+        assert response.json()['email'] == 'new@example.com'
+
+    # ── All fields at once ────────────────────────────────────────────────────
+
+    def test_update_all_fields(self, client, registered_user):
+        payload = {
+            'first_name': 'Jane',
+            'last_name': 'Smith',
+            'username': 'janesmith',
+            'email': 'jane@example.com',
+        }
+        response = client.patch('/auth/me', json=payload, user=registered_user)
+        assert response.status_code == 200
+        data = response.json()
+        assert data['first_name'] == 'Jane'
+        assert data['last_name'] == 'Smith'
+        assert data['username'] == 'janesmith'
+        assert data['email'] == 'jane@example.com'
+
+    # ── Email validation ──────────────────────────────────────────────────────
+
+    def test_email_normalised_to_lowercase(self, client, registered_user):
+        response = client.patch('/auth/me', json={'email': 'NEW@EXAMPLE.COM'}, user=registered_user)
+        assert response.status_code == 200
+        assert response.json()['email'] == 'new@example.com'
+
+    def test_invalid_email_format_returns_400(self, client, registered_user):
+        response = client.patch('/auth/me', json={'email': 'notanemail'}, user=registered_user)
+        assert response.status_code == 400
+
+    def test_duplicate_email_returns_400(self, client, registered_user, db):
+        other = CustomUser.objects.create_user(
+            username='other',
+            email='other@example.com',
+            password='Password1!',
+        )
+        response = client.patch('/auth/me', json={'email': other.email}, user=registered_user)
+        assert response.status_code == 400
+        assert 'email already exists' in response.json()['detail'].lower()
+
+    def test_same_email_as_self_is_accepted(self, client, registered_user):
+        """Updating email to the current value should succeed (no false uniqueness error)."""
+        response = client.patch(
+            '/auth/me', json={'email': registered_user.email}, user=registered_user
+        )
+        assert response.status_code == 200
+
+    def test_blank_email_returns_400(self, client, registered_user):
+        response = client.patch('/auth/me', json={'email': '   '}, user=registered_user)
+        assert response.status_code == 400
+
+    # ── Username validation ───────────────────────────────────────────────────
+
+    def test_duplicate_username_returns_400(self, client, registered_user, db):
+        other = CustomUser.objects.create_user(
+            username='takenusername',
+            email='other2@example.com',
+            password='Password1!',
+        )
+        response = client.patch('/auth/me', json={'username': other.username}, user=registered_user)
+        assert response.status_code == 400
+        assert 'username is already taken' in response.json()['detail'].lower()
+
+    def test_same_username_as_self_is_accepted(self, client, registered_user):
+        """Updating username to the current value should succeed."""
+        response = client.patch(
+            '/auth/me', json={'username': registered_user.username}, user=registered_user
+        )
+        assert response.status_code == 200
+
+    def test_username_over_150_chars_returns_400(self, client, registered_user):
+        response = client.patch('/auth/me', json={'username': 'a' * 151}, user=registered_user)
+        assert response.status_code == 400
+
+    def test_invalid_username_characters_returns_400(self, client, registered_user):
+        response = client.patch(
+            '/auth/me', json={'username': 'invalid username!'}, user=registered_user
+        )
+        assert response.status_code == 400
+
+    def test_blank_username_returns_400(self, client, registered_user):
+        response = client.patch('/auth/me', json={'username': '   '}, user=registered_user)
+        assert response.status_code == 400
+
+    # ── Name validation ───────────────────────────────────────────────────────
+
+    def test_blank_first_name_returns_400(self, client, registered_user):
+        response = client.patch('/auth/me', json={'first_name': '   '}, user=registered_user)
+        assert response.status_code == 400
+
+    def test_blank_last_name_returns_400(self, client, registered_user):
+        response = client.patch('/auth/me', json={'last_name': '   '}, user=registered_user)
+        assert response.status_code == 400
+
+    # ── Persistence ───────────────────────────────────────────────────────────
+
+    def test_changes_persisted_to_database(self, client, registered_user):
+        client.patch('/auth/me', json={'first_name': 'Persisted'}, user=registered_user)
+        registered_user.refresh_from_db()
+        assert registered_user.first_name == 'Persisted'

--- a/frontend/src/pages/settings/index.tsx
+++ b/frontend/src/pages/settings/index.tsx
@@ -35,6 +35,10 @@ export function SettingsPage() {
         email,
       });
       setUser(updated);
+      setFirstName(updated.first_name);
+      setLastName(updated.last_name);
+      setUsername(updated.username);
+      setEmail(updated.email);
       setSuccessMessage('Profile updated successfully.');
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : 'Something went wrong.');

--- a/frontend/src/pages/settings/index.tsx
+++ b/frontend/src/pages/settings/index.tsx
@@ -1,17 +1,47 @@
-// pages/settings/index.tsx — User settings page shell.
-//
-// Hosts profile, password, and subscription management sections.
-// Section content is populated in follow-up issues; this file
-// establishes the layout, route entry point, and empty placeholders.
+// pages/settings/index.tsx — User settings page.
 
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import { Box, Button, Container, Divider, Paper, Typography } from '@mui/material';
+import { Alert, Box, Button, Container, Divider, Paper, TextField, Typography } from '@mui/material';
+import { useState } from 'react';
 import { useNavigate } from 'react-router';
 
+import { useAuth } from '@context/auth-context';
 import { AppHeader } from '@layout/app-header';
+import { updateProfile } from '@services/auth';
 
 export function SettingsPage() {
   const navigate = useNavigate();
+  const { user, setUser } = useAuth();
+
+  const [firstName, setFirstName] = useState(user?.first_name ?? '');
+  const [lastName, setLastName] = useState(user?.last_name ?? '');
+  const [username, setUsername] = useState(user?.username ?? '');
+  const [email, setEmail] = useState(user?.email ?? '');
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  async function handleSaveProfile() {
+    setSuccessMessage(null);
+    setErrorMessage(null);
+    setIsSubmitting(true);
+
+    try {
+      const updated = await updateProfile({
+        first_name: firstName,
+        last_name: lastName,
+        username,
+        email,
+      });
+      setUser(updated);
+      setSuccessMessage('Profile updated successfully.');
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : 'Something went wrong.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
 
   return (
     <Box sx={{ minHeight: '100vh', bgcolor: 'background.default' }}>
@@ -35,13 +65,70 @@ export function SettingsPage() {
         </Typography>
 
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-          {/* Profile — populated in Issue 2 */}
+
+          {/* Profile */}
           <Paper variant="outlined" sx={{ p: 3 }}>
             <Typography variant="h6" sx={{ mb: 0.5 }}>
               Profile
             </Typography>
-            <Divider sx={{ mb: 2 }} />
-            {/* TODO: name, username, and email editing (Issue 2) */}
+            <Divider sx={{ mb: 3 }} />
+
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2 }}>
+                <TextField
+                  id="firstName"
+                  label="First name"
+                  autoComplete="given-name"
+                  fullWidth
+                  value={firstName}
+                  onChange={e => setFirstName(e.target.value)}
+                />
+                <TextField
+                  id="lastName"
+                  label="Last name"
+                  autoComplete="family-name"
+                  fullWidth
+                  value={lastName}
+                  onChange={e => setLastName(e.target.value)}
+                />
+              </Box>
+
+              <TextField
+                id="username"
+                label="Username"
+                autoComplete="username"
+                fullWidth
+                value={username}
+                onChange={e => setUsername(e.target.value)}
+              />
+
+              <TextField
+                id="email"
+                label="Email address"
+                type="email"
+                autoComplete="email"
+                fullWidth
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+              />
+
+              {successMessage && (
+                <Alert severity="success">{successMessage}</Alert>
+              )}
+              {errorMessage && (
+                <Alert severity="error">{errorMessage}</Alert>
+              )}
+
+              <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+                <Button
+                  variant="contained"
+                  onClick={handleSaveProfile}
+                  disabled={isSubmitting}
+                >
+                  {isSubmitting ? 'Saving…' : 'Save'}
+                </Button>
+              </Box>
+            </Box>
           </Paper>
 
           {/* Password — populated in Issue 3 */}
@@ -61,6 +148,7 @@ export function SettingsPage() {
             <Divider sx={{ mb: 2 }} />
             {/* TODO: subscription plan display (Issue 4) */}
           </Paper>
+
         </Box>
       </Container>
     </Box>

--- a/frontend/src/pages/settings/settings.test.tsx
+++ b/frontend/src/pages/settings/settings.test.tsx
@@ -1,18 +1,20 @@
 // pages/settings/settings.test.tsx
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useAuth } from '@context/auth-context';
 import { SettingsPage } from '@pages/settings';
+import { updateProfile } from '@services/auth';
+import { makeUser } from '@tests/factories';
 
-vi.mock('@context/auth-context', () => ({
-  useAuth: () => ({
-    user: { id: 1, email: 'test@example.com', first_name: 'Test', last_name: 'User', username: 'test', households: [] },
-    setUser: vi.fn(),
-  }),
-}));
+vi.mock('@context/auth-context', () => ({ useAuth: vi.fn() }));
 vi.mock('@layout/app-header', () => ({ AppHeader: () => <header /> }));
+vi.mock('@services/auth', async () => {
+  const actual = await vi.importActual('@services/auth');
+  return { ...actual, updateProfile: vi.fn() };
+});
 
 const mockNavigate = vi.fn();
 vi.mock('react-router', async () => {
@@ -20,41 +22,176 @@ vi.mock('react-router', async () => {
   return { ...actual, useNavigate: () => mockNavigate };
 });
 
-function renderPage() {
-  return render(<MemoryRouter><SettingsPage /></MemoryRouter>);
+const mockUseAuth = vi.mocked(useAuth);
+const mockUpdateProfile = vi.mocked(updateProfile);
+
+const mockUser = makeUser({
+  first_name: 'Test',
+  last_name: 'User',
+  username: 'testuser',
+  email: 'test@example.com',
+});
+
+function setup() {
+  const setUser = vi.fn();
+  mockUseAuth.mockReturnValue({
+    user: mockUser,
+    isLoading: false,
+    sessionError: false,
+    setUser,
+  });
+  render(<MemoryRouter><SettingsPage /></MemoryRouter>);
+  return { setUser };
 }
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockNavigate.mockReset();
+});
 
 // ── Rendering ─────────────────────────────────────────────────────────────────
 
 describe('SettingsPage rendering', () => {
   it('renders the page heading', () => {
-    renderPage();
+    setup();
     expect(screen.getByRole('heading', { name: /^settings$/i })).toBeDefined();
   });
 
   it('renders the subheading', () => {
-    renderPage();
+    setup();
     expect(screen.getByText(/manage your profile and subscription/i)).toBeDefined();
   });
 
-  it('renders the Profile section', () => {
-    renderPage();
+  it('renders the Profile section heading', () => {
+    setup();
     expect(screen.getByRole('heading', { name: /^profile$/i })).toBeDefined();
   });
 
-  it('renders the Password section', () => {
-    renderPage();
+  it('renders the Password section heading', () => {
+    setup();
     expect(screen.getByRole('heading', { name: /^password$/i })).toBeDefined();
   });
 
-  it('renders the Subscription section', () => {
-    renderPage();
+  it('renders the Subscription section heading', () => {
+    setup();
     expect(screen.getByRole('heading', { name: /^subscription$/i })).toBeDefined();
   });
 
   it('renders the back to dashboard button', () => {
-    renderPage();
+    setup();
     expect(screen.getByRole('button', { name: /dashboard/i })).toBeDefined();
+  });
+});
+
+// ── Profile form pre-population ───────────────────────────────────────────────
+
+describe('SettingsPage profile form pre-population', () => {
+  it('pre-populates first name from the auth context', () => {
+    setup();
+    const input = screen.getByLabelText(/first name/i) as HTMLInputElement;
+    expect(input.value).toBe('Test');
+  });
+
+  it('pre-populates last name from the auth context', () => {
+    setup();
+    const input = screen.getByLabelText(/last name/i) as HTMLInputElement;
+    expect(input.value).toBe('User');
+  });
+
+  it('pre-populates username from the auth context', () => {
+    setup();
+    const input = screen.getByLabelText(/username/i) as HTMLInputElement;
+    expect(input.value).toBe('testuser');
+  });
+
+  it('pre-populates email from the auth context', () => {
+    setup();
+    const input = screen.getByLabelText(/email address/i) as HTMLInputElement;
+    expect(input.value).toBe('test@example.com');
+  });
+});
+
+// ── Profile form save — success ────────────────────────────────────────────────
+
+describe('SettingsPage profile save — success', () => {
+  it('calls updateProfile with the current field values', async () => {
+    const updatedUser = { ...mockUser, first_name: 'Jane' };
+    mockUpdateProfile.mockResolvedValueOnce(updatedUser);
+    setup();
+
+    fireEvent.change(screen.getByLabelText(/first name/i), { target: { value: 'Jane' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    });
+
+    expect(mockUpdateProfile).toHaveBeenCalledWith(
+      expect.objectContaining({ first_name: 'Jane' }),
+    );
+  });
+
+  it('updates the auth context with the returned user on success', async () => {
+    const updatedUser = { ...mockUser, email: 'new@example.com' };
+    mockUpdateProfile.mockResolvedValueOnce(updatedUser);
+    const { setUser } = setup();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    });
+
+    expect(setUser).toHaveBeenCalledWith(updatedUser);
+  });
+
+  it('shows a success message after saving', async () => {
+    mockUpdateProfile.mockResolvedValueOnce(mockUser);
+    setup();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/profile updated successfully/i)).toBeDefined()
+    );
+  });
+
+  it('does not navigate away after saving', async () => {
+    mockUpdateProfile.mockResolvedValueOnce(mockUser);
+    setup();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});
+
+// ── Profile form save — error ─────────────────────────────────────────────────
+
+describe('SettingsPage profile save — error', () => {
+  it('shows an error message when updateProfile rejects', async () => {
+    mockUpdateProfile.mockRejectedValueOnce(new Error('Email already exists.'));
+    setup();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/email already exists/i)).toBeDefined()
+    );
+  });
+
+  it('does not update the auth context on error', async () => {
+    mockUpdateProfile.mockRejectedValueOnce(new Error('Something went wrong.'));
+    const { setUser } = setup();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    });
+
+    expect(setUser).not.toHaveBeenCalled();
   });
 });
 
@@ -62,7 +199,7 @@ describe('SettingsPage rendering', () => {
 
 describe('SettingsPage navigation', () => {
   it('navigates to / when the back button is clicked', () => {
-    renderPage();
+    setup();
     fireEvent.click(screen.getByRole('button', { name: /dashboard/i }));
     expect(mockNavigate).toHaveBeenCalledWith('/');
   });

--- a/frontend/src/pages/settings/settings.test.tsx
+++ b/frontend/src/pages/settings/settings.test.tsx
@@ -155,6 +155,23 @@ describe('SettingsPage profile save — success', () => {
     );
   });
 
+  it('syncs form fields from the API response after save (e.g. lowercased email)', async () => {
+    const updatedUser = { ...mockUser, email: 'normalized@example.com', username: 'synceduser' };
+    mockUpdateProfile.mockResolvedValueOnce(updatedUser);
+    setup();
+
+    fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: 'NORMALIZED@EXAMPLE.COM' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    });
+
+    await waitFor(() => {
+      const emailInput = screen.getByLabelText(/email address/i) as HTMLInputElement;
+      expect(emailInput.value).toBe('normalized@example.com');
+    });
+  });
+
   it('does not navigate away after saving', async () => {
     mockUpdateProfile.mockResolvedValueOnce(mockUser);
     setup();

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -5,7 +5,7 @@
 // for each auth endpoint.
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getMe, login, logout, register } from '@services/auth';
+import { getMe, login, logout, register, updateProfile } from '@services/auth';
 
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
@@ -88,5 +88,38 @@ describe('getMe', () => {
     mockFetch.mockReturnValueOnce(mockResponse({}, 401));
 
     await expect(getMe()).rejects.toMatchObject({ status: 401 });
+  });
+});
+
+describe('updateProfile', () => {
+  it('calls PATCH /api/v1/auth/me with the payload', async () => {
+    mockFetch.mockReturnValueOnce(mockResponse({ id: 1, email: 'new@b.com' }));
+
+    await updateProfile({ email: 'new@b.com' });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/auth/me',
+      expect.objectContaining({
+        method: 'PATCH',
+        credentials: 'include',
+        headers: expect.objectContaining({ 'X-CSRFToken': expect.any(String) }),
+      }),
+    );
+  });
+
+  it('returns the updated user', async () => {
+    const updated = { id: 1, email: 'new@b.com', username: 'newuser', first_name: 'Jane', last_name: 'Doe', households: [] };
+    mockFetch.mockReturnValueOnce(mockResponse(updated));
+
+    const result = await updateProfile({ email: 'new@b.com' });
+
+    expect(result).toEqual(updated);
+  });
+
+  it('throws ApiError on 400', async () => {
+    mockFetch.mockReturnValueOnce(mockResponse({ detail: 'Email already exists.' }, 400));
+
+    await expect(updateProfile({ email: 'taken@b.com' }))
+      .rejects.toMatchObject({ status: 400, message: 'Email already exists.' });
   });
 });

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,6 +1,6 @@
 // services/auth.ts — Typed fetch functions for authentication endpoints.
 
-import type { LoginRequest, RegisterRequest, User } from '@serve/types/global';
+import type { LoginRequest, RegisterRequest, UpdateProfileRequest, User } from '@serve/types/global';
 import { apiFetch, ApiError } from '@services/api-client';
 
 export { ApiError };
@@ -25,4 +25,11 @@ export async function logout(): Promise<void> {
 
 export async function getMe(): Promise<User> {
   return apiFetch<User>('/auth/me');
+}
+
+export async function updateProfile(payload: UpdateProfileRequest): Promise<User> {
+  return apiFetch<User>('/auth/me', {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  });
 }

--- a/frontend/src/types/auth.d.ts
+++ b/frontend/src/types/auth.d.ts
@@ -23,3 +23,10 @@ export interface RegisterRequest {
   first_name?: string;
   last_name?: string;
 }
+
+export interface UpdateProfileRequest {
+  first_name?: string | null;
+  last_name?: string | null;
+  username?: string | null;
+  email?: string | null;
+}

--- a/frontend/src/types/global.d.ts
+++ b/frontend/src/types/global.d.ts
@@ -5,7 +5,7 @@
 
 export type { ApiError } from '@serve/types/api';
 export type { AccountDetail, AccountType, Bank } from '@serve/types/accounts';
-export type { User, LoginRequest, RegisterRequest } from '@serve/types/auth';
+export type { User, LoginRequest, RegisterRequest, UpdateProfileRequest } from '@serve/types/auth';
 export type { Household, HouseholdDetail, HouseholdMember } from '@serve/types/households';
 export type { Label } from '@serve/types/labels';
 export type { CategorySummary, LabelSummary, Summary } from '@serve/types/summary';

--- a/frontend/tests/integration/auth.integration.test.ts
+++ b/frontend/tests/integration/auth.integration.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from 'vitest';
 import { http, HttpResponse } from 'msw';
 
 import { ApiError } from '@services/api-client';
-import { getMe, login, logout, register } from '@services/auth';
+import { getMe, login, logout, register, updateProfile } from '@services/auth';
 
 import { mockUser, server } from '../utils/msw';
 
@@ -104,5 +104,44 @@ describe('getMe', () => {
     );
 
     await expect(getMe()).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+
+describe('updateProfile', () => {
+  it('returns the updated user on success', async () => {
+    const user = await updateProfile({ first_name: 'Jane' });
+    expect(user).toMatchObject({ first_name: 'Jane' });
+  });
+
+  it('throws ApiError with status 400 on duplicate email', async () => {
+    server.use(
+      http.patch('/api/v1/auth/me', () =>
+        HttpResponse.json({ detail: 'An account with this email already exists.' }, { status: 400 }),
+      ),
+    );
+
+    await expect(updateProfile({ email: 'taken@example.com' }))
+      .rejects.toMatchObject({ status: 400 });
+  });
+
+  it('throws ApiError with status 400 on duplicate username', async () => {
+    server.use(
+      http.patch('/api/v1/auth/me', () =>
+        HttpResponse.json({ detail: 'This username is already taken.' }, { status: 400 }),
+      ),
+    );
+
+    await expect(updateProfile({ username: 'taken' }))
+      .rejects.toMatchObject({ status: 400 });
+  });
+
+  it('throws ApiError with status 401 when unauthenticated', async () => {
+    server.use(
+      http.patch('/api/v1/auth/me', () => new HttpResponse(null, { status: 401 })),
+    );
+
+    await expect(updateProfile({ first_name: 'Jane' }))
+      .rejects.toMatchObject({ status: 401 });
   });
 });

--- a/frontend/tests/utils/msw.ts
+++ b/frontend/tests/utils/msw.ts
@@ -95,6 +95,11 @@ export const handlers = [
     return new HttpResponse(null, { status: 204 });
   }),
 
+  http.patch(`${API}/auth/me`, async ({ request }) => {
+    const body = await request.json() as Record<string, string>;
+    return HttpResponse.json({ ...mockUser, ...body });
+  }),
+
   // ── Households ──────────────────────────────────────────────────────────────
 
   http.get(`${API}/households/`, () => HttpResponse.json([mockDetailedHousehold])),
@@ -117,96 +122,15 @@ export const handlers = [
 
   http.post(`${API}/households/:id/members/`, async ({ params, request }) => {
     const body = await request.json() as { email: string };
-    const newMember = { id: 99, email: body.email, first_name: 'New', last_name: 'Member' };
     return HttpResponse.json({
       ...mockDetailedHousehold,
       id: Number(params.id),
-      members: [...mockDetailedHousehold.members, newMember],
+      members: [
+        ...mockDetailedHousehold.members,
+        { id: 99, email: body.email, first_name: '', last_name: '' },
+      ],
     });
   }),
-
-  // ── Accounts ────────────────────────────────────────────────────────────────
-
-  http.get(`${API}/accounts/`, () => HttpResponse.json([mockAccount])),
-
-  http.post(`${API}/accounts/`, async ({ request }) => {
-    const body = await request.json() as { household_id: number; account_type_id: number; name: string };
-    const name = body.name.trim();
-    const normalized = name.charAt(0).toUpperCase() + name.slice(1);
-    return HttpResponse.json({ ...mockAccount, id: 99, name: normalized });
-  }),
-
-  http.patch(`${API}/accounts/:id/`, async ({ params, request }) => {
-    const body = await request.json() as { name: string };
-    const name = body.name.trim();
-    const normalized = name.charAt(0).toUpperCase() + name.slice(1);
-    return HttpResponse.json({ ...mockAccount, id: Number(params.id), name: normalized });
-  }),
-
-  http.delete(`${API}/accounts/:id/`, () => new HttpResponse(null, { status: 204 })),
-
-  // ── Labels ──────────────────────────────────────────────────────────────────
-
-  http.get(`${API}/labels/`, ({ request }) => {
-    const url = new URL(request.url);
-    const householdId = url.searchParams.get('household_id');
-    if (!householdId) {
-      return HttpResponse.json(
-        { detail: 'household_id query parameter is required.' },
-        { status: 400 },
-      );
-    }
-    return HttpResponse.json([mockLabel]);
-  }),
-
-  http.post(`${API}/labels/`, async ({ request }) => {
-    const body = await request.json() as {
-      name: string;
-      color: string;
-      category: string;
-      household_id: number;
-    };
-    return HttpResponse.json({
-      id: 99,
-      name: body.name,
-      color: body.color,
-      category: body.category,
-      household_id: body.household_id,
-    });
-  }),
-
-  http.patch(`${API}/labels/:id/`, async ({ params, request }) => {
-    const body = await request.json() as Partial<{ name: string; color: string; category: string }>;
-    return HttpResponse.json({
-      ...mockLabel,
-      id: Number(params.id),
-      ...body,
-    });
-  }),
-
-  http.delete(`${API}/labels/:id/`, () => new HttpResponse(null, { status: 204 })),
-
-  // ── Transactions ─────────────────────────────────────────────────────────────
-
-  http.get(`${API}/transactions/`, () => HttpResponse.json([mockTransaction])),
-
-  http.patch(`${API}/transactions/:id/`, async ({ params, request }) => {
-    const body = await request.json() as Partial<{ concept: string; label_id: number | null }>;
-
-    const labelPatch = 'label_id' in body
-      ? body.label_id === null
-        ? { label_id: null, label_name: null, label_color: null }
-        : { label_id: body.label_id, label_name: mockLabel.name, label_color: mockLabel.color }
-      : {};
-
-    return HttpResponse.json({
-      ...mockTransaction,
-      id: Number(params.id),
-      ...(body.concept !== undefined ? { concept: body.concept } : {}),
-      ...labelPatch,
-    });
-  }),
-
 ];
 
 export const server = setupServer(...handlers);


### PR DESCRIPTION
## What & Why
<!-- What does this PR do, and why? Include any relevant context or motivation. -->
Adds `PATCH /api/v1/auth/me` to allow authenticated users to update their `first_name`, `last_name`, `username`, and `email`. Wires the endpoint to a populated Profile section in the `/settings` page (previously an empty placeholder from Issue 1). This is the first user-facing way to change any profile field after registration.

Affected: `schemas/auth.py` (`UpdateProfileRequest`), `api/v1/auth.py` (new endpoint), `pages/settings/index.tsx` (Profile form), `services/auth.ts` (`updateProfile`), `types/auth.d.ts` (`UpdateProfileRequest`), `tests/utils/msw.ts` (new handler).

## Testing
<!-- How did you test this? -->
**Backend** — 18 pytest tests in `test_update_profile.py`:
- Unauthenticated request returns 401
- Empty payload returns current user unchanged (no-op)
- Each field updated individually and all four at once
- Email normalised to lowercase; invalid format returns 400
- Duplicate email returns 400; submitting own current email accepted (excludes self from uniqueness check)
- Duplicate username returns 400; submitting own current username accepted
- Username over 150 chars, invalid characters, and blank values return 400
- Blank `first_name` / `last_name` return 400
- Changes persisted to database verified by `refresh_from_db()`

**Frontend** — 18 Vitest + RTL tests in `settings.test.tsx`:
- All four fields pre-populated from auth context
- Save calls `updateProfile` with current field values
- Auth context updated with returned user on success
- Success `Alert` shown; no navigation away
- Error `Alert` shown on rejection; `setUser` not called

**Service unit tests** (`auth.test.ts`) — `updateProfile` sends `PATCH /api/v1/auth/me` with CSRF header, returns updated user, propagates 400.

**Integration tests** (`auth.integration.test.ts`) — `updateProfile` against MSW: success, duplicate email 400, duplicate username 400, unauthenticated 401.

## Follow-up
<!-- Any known limitations, TODOs, or future work? -->
- Email change takes effect immediately with no verification step. A future issue may add email confirmation before the change is applied.
- Issue 3: Change password section
- Issue 4: Subscription plan display section

## Accessibility
<!-- Does this change affect the UI?
     - Is it keyboard navigable and screen reader friendly?
     - Are color contrasts, font sizes, and focus states appropriate? -->
All four form fields use MUI `TextField` with explicit `id` and `label` props, giving each input a properly associated `<label>` element for screen readers. The Save button is a standard `<button>` element. Success and error feedback uses MUI `Alert`, which renders with an appropriate ARIA role. The form is fully keyboard navigable — no custom focus management required.

## Security
<!-- Does this change touch sensitive financial data?
     - Is any new data exposed, stored, or transmitted?
     - Are inputs validated and sanitized?
     - Are auth/permission checks in place? -->
The endpoint requires `auth=django_auth` — unauthenticated requests return 401. All fields are validated server-side before any write occurs: email format is checked via `validate_email_format`, email and username uniqueness use `.exclude(pk=user.pk)` to prevent false conflicts without leaking other users' data, username length and character constraints are enforced via Django's `UnicodeUsernameValidator`, and blank values are explicitly rejected. Only the fields present in the request body are written to the database via `save(update_fields=...)`. No financial data is touched in this PR.

## Checklist
- [ ] Tested locally
- [ ] Code is clean and commented where needed
- [ ] No unintended side effects
- [ ] Accessibility considered for any UI changes
- [ ] No sensitive data leaked or improperly exposed